### PR TITLE
feat(shared): Core DDD Infrastructure Foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ ignore_missing_imports = true
 testpaths = ["tests"]
 pythonpath = ["src"]
 asyncio_mode = "auto"
-addopts = "-v --cov=src --cov-report=term-missing"
+addopts = "-v"
 
 [tool.uv]
 dev-dependencies = []

--- a/src/backend/shared/domain/base/aggregate_root.py
+++ b/src/backend/shared/domain/base/aggregate_root.py
@@ -16,14 +16,11 @@ class AggregateRoot(Entity):
 
     _domain_events: List[DomainEvent] = []
 
-    class Config:
-        """Pydantic configuration."""
-
-        from_attributes = True
-        validate_assignment = True
-        arbitrary_types_allowed = True
-        # Exclude private fields from serialization
-        fields = {"_domain_events": {"exclude": True}}
+    model_config = {
+        "from_attributes": True,
+        "validate_assignment": True,
+        "arbitrary_types_allowed": True,
+    }
 
     def add_domain_event(self, event: DomainEvent) -> None:
         """Add a domain event to be published."""

--- a/src/backend/shared/infrastructure/__init__.py
+++ b/src/backend/shared/infrastructure/__init__.py
@@ -1,0 +1,12 @@
+"""Shared infrastructure components."""
+
+from .messaging import DomainEventDispatcher, get_event_dispatcher
+from .persistence import BaseMapper, BaseModel, SQLAlchemyUnitOfWork
+
+__all__ = [
+    "BaseMapper",
+    "BaseModel",
+    "SQLAlchemyUnitOfWork",
+    "DomainEventDispatcher",
+    "get_event_dispatcher",
+]

--- a/src/backend/shared/infrastructure/messaging/__init__.py
+++ b/src/backend/shared/infrastructure/messaging/__init__.py
@@ -1,0 +1,8 @@
+"""Messaging infrastructure."""
+
+from .event_dispatcher import DomainEventDispatcher, get_event_dispatcher
+
+__all__ = [
+    "DomainEventDispatcher",
+    "get_event_dispatcher",
+]

--- a/src/backend/shared/infrastructure/messaging/event_dispatcher.py
+++ b/src/backend/shared/infrastructure/messaging/event_dispatcher.py
@@ -1,0 +1,88 @@
+"""Domain event dispatcher implementation."""
+
+import logging
+from collections import defaultdict
+from typing import Callable, Type
+
+from src.backend.shared.domain.base import DomainEvent
+
+logger = logging.getLogger(__name__)
+
+EventHandler = Callable[[DomainEvent], None]
+
+
+class DomainEventDispatcher:
+    """In-memory domain event dispatcher.
+
+    Handles registration and dispatching of domain events to handlers.
+    Events are dispatched synchronously after transaction commit.
+    """
+
+    def __init__(self) -> None:
+        """Initialize event dispatcher."""
+        self._handlers: dict[Type[DomainEvent], list[EventHandler]] = defaultdict(list)
+
+    def register(
+        self, event_type: Type[DomainEvent], handler: EventHandler
+    ) -> None:
+        """Register an event handler.
+
+        Args:
+            event_type: Type of domain event
+            handler: Handler function
+        """
+        self._handlers[event_type].append(handler)
+        logger.debug(
+            f"Registered handler {handler.__name__} for event {event_type.__name__}"
+        )
+
+    def dispatch(self, event: DomainEvent) -> None:
+        """Dispatch a domain event to all registered handlers.
+
+        Args:
+            event: Domain event to dispatch
+        """
+        event_type = type(event)
+        handlers = self._handlers.get(event_type, [])
+
+        if not handlers:
+            logger.debug(f"No handlers registered for event {event_type.__name__}")
+            return
+
+        logger.info(f"Dispatching event {event_type.__name__} to {len(handlers)} handlers")
+
+        for handler in handlers:
+            try:
+                handler(event)
+            except Exception as e:
+                logger.error(
+                    f"Error dispatching event {event_type.__name__} to {handler.__name__}: {e}",
+                    exc_info=True,
+                )
+
+    def dispatch_all(self, events: list[DomainEvent]) -> None:
+        """Dispatch multiple domain events.
+
+        Args:
+            events: List of domain events
+        """
+        for event in events:
+            self.dispatch(event)
+
+    def clear_handlers(self) -> None:
+        """Clear all registered handlers (useful for testing)."""
+        self._handlers.clear()
+        logger.debug("Cleared all event handlers")
+
+
+# Global dispatcher instance
+_dispatcher = DomainEventDispatcher()
+
+
+def get_event_dispatcher() -> DomainEventDispatcher:
+    """Get the global event dispatcher instance.
+
+    Returns:
+        Domain event dispatcher
+    """
+    return _dispatcher

--- a/src/backend/shared/infrastructure/persistence/__init__.py
+++ b/src/backend/shared/infrastructure/persistence/__init__.py
@@ -1,0 +1,11 @@
+"""Persistence infrastructure."""
+
+from .base_mapper import BaseMapper
+from .base_model import BaseModel
+from .unit_of_work import SQLAlchemyUnitOfWork
+
+__all__ = [
+    "BaseMapper",
+    "BaseModel",
+    "SQLAlchemyUnitOfWork",
+]

--- a/src/backend/shared/infrastructure/persistence/base_mapper.py
+++ b/src/backend/shared/infrastructure/persistence/base_mapper.py
@@ -1,0 +1,70 @@
+"""Base mapper for entity-model conversion."""
+
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel as PydanticModel
+from sqlalchemy.orm import DeclarativeBase
+
+TEntity = TypeVar("TEntity", bound=PydanticModel)
+TModel = TypeVar("TModel", bound=DeclarativeBase)
+
+
+class BaseMapper(ABC, Generic[TEntity, TModel]):
+    """Base mapper for converting between domain entities and ORM models.
+
+    This mapper handles the transformation between:
+    - Domain entities (Pydantic models with business logic)
+    - ORM models (SQLAlchemy models for persistence)
+
+    Subclasses must implement:
+    - to_domain(): Convert ORM model to domain entity
+    - to_orm(): Convert domain entity to ORM model
+    """
+
+    @abstractmethod
+    def to_domain(self, model: TModel) -> TEntity:
+        """Convert ORM model to domain entity.
+
+        Args:
+            model: SQLAlchemy ORM model
+
+        Returns:
+            Domain entity
+        """
+        pass
+
+    @abstractmethod
+    def to_orm(self, entity: TEntity, model: TModel | None = None) -> TModel:
+        """Convert domain entity to ORM model.
+
+        Args:
+            entity: Domain entity
+            model: Existing ORM model to update (optional)
+
+        Returns:
+            SQLAlchemy ORM model
+        """
+        pass
+
+    def to_domain_list(self, models: list[TModel]) -> list[TEntity]:
+        """Convert list of ORM models to domain entities.
+
+        Args:
+            models: List of SQLAlchemy ORM models
+
+        Returns:
+            List of domain entities
+        """
+        return [self.to_domain(model) for model in models]
+
+    def to_orm_list(self, entities: list[TEntity]) -> list[TModel]:
+        """Convert list of domain entities to ORM models.
+
+        Args:
+            entities: List of domain entities
+
+        Returns:
+            List of SQLAlchemy ORM models
+        """
+        return [self.to_orm(entity) for entity in entities]

--- a/src/backend/shared/infrastructure/persistence/base_model.py
+++ b/src/backend/shared/infrastructure/persistence/base_model.py
@@ -1,0 +1,39 @@
+"""Base ORM model for SQLAlchemy."""
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class BaseModel(DeclarativeBase):
+    """Base class for all SQLAlchemy ORM models.
+
+    Provides common fields:
+    - id: UUID primary key
+    - created_at: Timestamp of creation
+    - updated_at: Timestamp of last update
+    """
+
+    __abstract__ = True
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4, nullable=False
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return f"<{self.__class__.__name__}(id={self.id})>"

--- a/src/backend/shared/infrastructure/persistence/unit_of_work.py
+++ b/src/backend/shared/infrastructure/persistence/unit_of_work.py
@@ -1,0 +1,89 @@
+"""Unit of Work implementation for SQLAlchemy."""
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.backend.shared.application.interfaces import IUnitOfWork
+from src.backend.shared.domain.base import DomainEvent
+
+
+class SQLAlchemyUnitOfWork(IUnitOfWork):
+    """SQLAlchemy implementation of Unit of Work pattern.
+
+    Manages transaction boundaries and coordinates:
+    - Database session lifecycle
+    - Commit/rollback operations
+    - Domain event collection for post-commit dispatch
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize Unit of Work.
+
+        Args:
+            session: SQLAlchemy async session
+        """
+        self.session = session
+        self._domain_events: list[DomainEvent] = []
+
+    async def commit(self) -> None:
+        """Commit the transaction and collect domain events."""
+        # Collect domain events from all tracked entities before commit
+        self._collect_domain_events()
+
+        # Commit the transaction
+        await self.session.commit()
+
+    async def rollback(self) -> None:
+        """Rollback the transaction and clear domain events."""
+        await self.session.rollback()
+        self._domain_events.clear()
+
+    def collect_events(self) -> list[DomainEvent]:
+        """Get collected domain events for dispatching.
+
+        Returns:
+            List of domain events
+        """
+        return self._domain_events.copy()
+
+    def clear_events(self) -> None:
+        """Clear collected domain events."""
+        self._domain_events.clear()
+
+    async def __aenter__(self) -> "SQLAlchemyUnitOfWork":
+        """Enter the context manager.
+
+        Returns:
+            Self
+        """
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit the context manager.
+
+        Args:
+            exc_type: Exception type
+            exc_val: Exception value
+            exc_tb: Exception traceback
+        """
+        if exc_type is not None:
+            await self.rollback()
+        else:
+            # Events are collected in commit(), will be dispatched by caller
+            pass
+
+    def _collect_domain_events(self) -> None:
+        """Collect domain events from tracked aggregate roots.
+
+        Iterates through all objects in the session and extracts
+        domain events from aggregate roots.
+        """
+        for obj in self.session.identity_map.values():
+            # Check if object has domain events (aggregate root)
+            if hasattr(obj, "get_domain_events"):
+                events = obj.get_domain_events()
+                self._domain_events.extend(events)
+                # Clear events from aggregate after collection
+                if hasattr(obj, "clear_domain_events"):
+                    obj.clear_domain_events()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,13 @@ from sqlalchemy.orm import sessionmaker
 from src.backend.shared.infrastructure.database import Base
 
 
+# Configure anyio to only use asyncio backend
+@pytest.fixture(scope="session")
+def anyio_backend():
+    """Configure anyio to use only asyncio."""
+    return "asyncio"
+
+
 @pytest.fixture(scope="session")
 def event_loop() -> Generator:
     """Create an instance of the default event loop for the test session."""

--- a/tests/unit/backend/shared/__init__.py
+++ b/tests/unit/backend/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for shared backend components."""

--- a/tests/unit/backend/shared/test_base_mapper.py
+++ b/tests/unit/backend/shared/test_base_mapper.py
@@ -1,0 +1,161 @@
+"""Tests for base mapper."""
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel as PydanticModel
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.backend.shared.infrastructure.persistence import BaseMapper, BaseModel
+
+
+# Test fixtures
+class TestEntity(PydanticModel):
+    """Test domain entity."""
+
+    id: UUID
+    name: str
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class TestOrmModel(BaseModel):
+    """Test ORM model."""
+
+    __tablename__ = "test_entities"
+
+    name: Mapped[str] = mapped_column(nullable=False)
+
+
+class TestMapper(BaseMapper[TestEntity, TestOrmModel]):
+    """Test mapper implementation."""
+
+    def to_domain(self, model: TestOrmModel) -> TestEntity:
+        """Convert ORM to domain."""
+        return TestEntity.model_validate(model)
+
+    def to_orm(self, entity: TestEntity, model: TestOrmModel | None = None) -> TestOrmModel:
+        """Convert domain to ORM."""
+        if model is None:
+            model = TestOrmModel(
+                id=entity.id,
+                name=entity.name,
+                created_at=entity.created_at,
+                updated_at=entity.updated_at,
+            )
+        else:
+            model.name = entity.name
+            model.updated_at = entity.updated_at
+
+        return model
+
+
+@pytest.fixture
+def mapper() -> TestMapper:
+    """Create test mapper."""
+    return TestMapper()
+
+
+@pytest.fixture
+def test_entity() -> TestEntity:
+    """Create test entity."""
+    entity_id = uuid4()
+    now = datetime.utcnow()
+    return TestEntity(
+        id=entity_id,
+        name="Test Entity",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.fixture
+def test_orm_model() -> TestOrmModel:
+    """Create test ORM model."""
+    entity_id = uuid4()
+    now = datetime.utcnow()
+    model = TestOrmModel(
+        id=entity_id,
+        name="Test Model",
+        created_at=now,
+        updated_at=now,
+    )
+    return model
+
+
+def test_to_domain(mapper: TestMapper, test_orm_model: TestOrmModel) -> None:
+    """Test converting ORM model to domain entity."""
+    entity = mapper.to_domain(test_orm_model)
+
+    assert entity.id == test_orm_model.id
+    assert entity.name == test_orm_model.name
+    assert entity.created_at == test_orm_model.created_at
+    assert entity.updated_at == test_orm_model.updated_at
+
+
+def test_to_orm_new_model(mapper: TestMapper, test_entity: TestEntity) -> None:
+    """Test converting domain entity to new ORM model."""
+    model = mapper.to_orm(test_entity)
+
+    assert model.id == test_entity.id
+    assert model.name == test_entity.name
+    assert model.created_at == test_entity.created_at
+    assert model.updated_at == test_entity.updated_at
+
+
+def test_to_orm_update_existing(
+    mapper: TestMapper, test_entity: TestEntity, test_orm_model: TestOrmModel
+) -> None:
+    """Test updating existing ORM model from domain entity."""
+    test_entity.name = "Updated Name"
+    model = mapper.to_orm(test_entity, test_orm_model)
+
+    assert model is test_orm_model
+    assert model.name == "Updated Name"
+
+
+def test_to_domain_list(mapper: TestMapper) -> None:
+    """Test converting list of ORM models to domain entities."""
+    now = datetime.utcnow()
+    models = [
+        TestOrmModel(id=uuid4(), name="Model 1", created_at=now, updated_at=now),
+        TestOrmModel(id=uuid4(), name="Model 2", created_at=now, updated_at=now),
+        TestOrmModel(id=uuid4(), name="Model 3", created_at=now, updated_at=now),
+    ]
+
+    entities = mapper.to_domain_list(models)
+
+    assert len(entities) == 3
+    assert all(isinstance(e, TestEntity) for e in entities)
+    assert entities[0].name == "Model 1"
+    assert entities[1].name == "Model 2"
+    assert entities[2].name == "Model 3"
+
+
+def test_to_orm_list(mapper: TestMapper) -> None:
+    """Test converting list of domain entities to ORM models."""
+    entities = [
+        TestEntity(
+            id=uuid4(),
+            name="Entity 1",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        ),
+        TestEntity(
+            id=uuid4(),
+            name="Entity 2",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        ),
+    ]
+
+    models = mapper.to_orm_list(entities)
+
+    assert len(models) == 2
+    assert all(isinstance(m, TestOrmModel) for m in models)
+    assert models[0].name == "Entity 1"
+    assert models[1].name == "Entity 2"

--- a/tests/unit/backend/shared/test_event_dispatcher.py
+++ b/tests/unit/backend/shared/test_event_dispatcher.py
@@ -1,0 +1,155 @@
+"""Tests for domain event dispatcher."""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.backend.shared.domain.base import DomainEvent
+from src.backend.shared.infrastructure.messaging import (
+    DomainEventDispatcher,
+    get_event_dispatcher,
+)
+
+
+class TestEventA(DomainEvent):
+    """Test event A."""
+
+    data_a: str
+
+
+class TestEventB(DomainEvent):
+    """Test event B."""
+
+    data_b: int
+
+
+@pytest.fixture
+def dispatcher() -> DomainEventDispatcher:
+    """Create fresh dispatcher."""
+    disp = DomainEventDispatcher()
+    return disp
+
+
+def test_register_handler(dispatcher: DomainEventDispatcher) -> None:
+    """Test registering event handler."""
+    handler = MagicMock()
+    handler.__name__ = "test_handler"
+
+    dispatcher.register(TestEventA, handler)
+
+    assert TestEventA in dispatcher._handlers
+    assert handler in dispatcher._handlers[TestEventA]
+
+
+def test_dispatch_event(dispatcher: DomainEventDispatcher) -> None:
+    """Test dispatching event to handler."""
+    handler = MagicMock()
+    handler.__name__ = "test_handler"
+    dispatcher.register(TestEventA, handler)
+
+    event = TestEventA(aggregate_id=uuid4(), event_type="TestEventA", data_a="test")
+    dispatcher.dispatch(event)
+
+    handler.assert_called_once_with(event)
+
+
+def test_dispatch_to_multiple_handlers(dispatcher: DomainEventDispatcher) -> None:
+    """Test dispatching event to multiple handlers."""
+    handler1 = MagicMock()
+    handler1.__name__ = "test_handler1"
+    handler2 = MagicMock()
+    handler2.__name__ = "test_handler2"
+
+    dispatcher.register(TestEventA, handler1)
+    dispatcher.register(TestEventA, handler2)
+
+    event = TestEventA(aggregate_id=uuid4(), event_type="TestEventA", data_a="test")
+    dispatcher.dispatch(event)
+
+    handler1.assert_called_once_with(event)
+    handler2.assert_called_once_with(event)
+
+
+def test_dispatch_only_to_matching_handlers(dispatcher: DomainEventDispatcher) -> None:
+    """Test event only dispatched to handlers for that event type."""
+    handler_a = MagicMock()
+    handler_a.__name__ = "handler_a"
+    handler_b = MagicMock()
+    handler_b.__name__ = "handler_b"
+
+    dispatcher.register(TestEventA, handler_a)
+    dispatcher.register(TestEventB, handler_b)
+
+    event_a = TestEventA(aggregate_id=uuid4(), event_type="TestEventA", data_a="test")
+    dispatcher.dispatch(event_a)
+
+    handler_a.assert_called_once_with(event_a)
+    handler_b.assert_not_called()
+
+
+def test_dispatch_no_handlers(dispatcher: DomainEventDispatcher) -> None:
+    """Test dispatching event with no registered handlers."""
+    event = TestEventA(aggregate_id=uuid4(), event_type="TestEventA", data_a="test")
+
+    # Should not raise exception
+    dispatcher.dispatch(event)
+
+
+def test_dispatch_handler_exception(dispatcher: DomainEventDispatcher) -> None:
+    """Test handler exception doesn't stop other handlers."""
+    handler1 = MagicMock(side_effect=Exception("Handler error"))
+    handler1.__name__ = "handler1"
+    handler2 = MagicMock()
+    handler2.__name__ = "handler2"
+
+    dispatcher.register(TestEventA, handler1)
+    dispatcher.register(TestEventA, handler2)
+
+    event = TestEventA(aggregate_id=uuid4(), event_type="TestEventA", data_a="test")
+    dispatcher.dispatch(event)
+
+    # Both handlers should be called despite first one failing
+    handler1.assert_called_once()
+    handler2.assert_called_once()
+
+
+def test_dispatch_all(dispatcher: DomainEventDispatcher) -> None:
+    """Test dispatching multiple events."""
+    handler_a = MagicMock()
+    handler_a.__name__ = "handler_a"
+    handler_b = MagicMock()
+    handler_b.__name__ = "handler_b"
+
+    dispatcher.register(TestEventA, handler_a)
+    dispatcher.register(TestEventB, handler_b)
+
+    events = [
+        TestEventA(aggregate_id=uuid4(), event_type="TestEventA", data_a="test"),
+        TestEventB(aggregate_id=uuid4(), event_type="TestEventB", data_b=42),
+    ]
+
+    dispatcher.dispatch_all(events)
+
+    handler_a.assert_called_once()
+    handler_b.assert_called_once()
+
+
+def test_clear_handlers(dispatcher: DomainEventDispatcher) -> None:
+    """Test clearing all handlers."""
+    handler = MagicMock()
+    handler.__name__ = "test_handler"
+    dispatcher.register(TestEventA, handler)
+
+    dispatcher.clear_handlers()
+
+    assert len(dispatcher._handlers) == 0
+
+
+def test_get_event_dispatcher() -> None:
+    """Test getting global dispatcher instance."""
+    dispatcher1 = get_event_dispatcher()
+    dispatcher2 = get_event_dispatcher()
+
+    # Should return same instance
+    assert dispatcher1 is dispatcher2

--- a/tests/unit/backend/shared/test_unit_of_work.py
+++ b/tests/unit/backend/shared/test_unit_of_work.py
@@ -1,0 +1,142 @@
+"""Tests for Unit of Work."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.backend.shared.domain.base import AggregateRoot, DomainEvent
+from src.backend.shared.infrastructure.persistence import SQLAlchemyUnitOfWork
+
+
+class TestEvent(DomainEvent):
+    """Test domain event."""
+
+    test_data: str
+
+
+class TestAggregate(AggregateRoot):
+    """Test aggregate root."""
+
+    name: str
+
+
+@pytest.fixture
+def mock_session() -> AsyncSession:
+    """Create mock async session."""
+    session = MagicMock(spec=AsyncSession)
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.identity_map = {}
+    return session
+
+
+@pytest.fixture
+def uow(mock_session: AsyncSession) -> SQLAlchemyUnitOfWork:
+    """Create unit of work."""
+    return SQLAlchemyUnitOfWork(mock_session)
+
+
+@pytest.mark.anyio
+async def test_commit(uow: SQLAlchemyUnitOfWork) -> None:
+    """Test commit transaction."""
+    await uow.commit()
+
+    uow.session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_rollback(uow: SQLAlchemyUnitOfWork) -> None:
+    """Test rollback transaction."""
+    await uow.rollback()
+
+    uow.session.rollback.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_rollback_clears_events(uow: SQLAlchemyUnitOfWork) -> None:
+    """Test rollback clears domain events."""
+    # Add some events
+    uow._domain_events = [
+        TestEvent(aggregate_id=uuid4(), event_type="TestEvent", test_data="data")
+    ]
+
+    await uow.rollback()
+
+    assert len(uow._domain_events) == 0
+
+
+@pytest.mark.anyio
+async def test_collect_events_from_aggregates(mock_session: AsyncSession) -> None:
+    """Test collecting domain events from aggregate roots."""
+    # Create aggregate with events
+    aggregate = TestAggregate(name="Test")
+    event = TestEvent(
+        aggregate_id=aggregate.id,
+        event_type="TestEvent",
+        test_data="test data",
+    )
+    aggregate.add_domain_event(event)
+
+    # Add to session identity map
+    mock_session.identity_map = {aggregate.id: aggregate}
+
+    uow = SQLAlchemyUnitOfWork(mock_session)
+    await uow.commit()
+
+    # Check events were collected
+    events = uow.collect_events()
+    assert len(events) == 1
+    assert events[0] == event
+
+    # Check aggregate events were cleared
+    assert len(aggregate.get_domain_events()) == 0
+
+
+@pytest.mark.anyio
+async def test_context_manager_success(mock_session: AsyncSession) -> None:
+    """Test context manager on success."""
+    async with SQLAlchemyUnitOfWork(mock_session) as uow:
+        assert uow.session == mock_session
+
+    # Session should not be rolled back on success
+    mock_session.rollback.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_context_manager_exception(mock_session: AsyncSession) -> None:
+    """Test context manager on exception."""
+    try:
+        async with SQLAlchemyUnitOfWork(mock_session):
+            raise ValueError("Test error")
+    except ValueError:
+        pass
+
+    # Session should be rolled back on exception
+    mock_session.rollback.assert_called_once()
+
+
+def test_collect_events_returns_copy(uow: SQLAlchemyUnitOfWork) -> None:
+    """Test collect_events returns a copy."""
+    event = TestEvent(aggregate_id=uuid4(), event_type="TestEvent", test_data="data")
+    uow._domain_events = [event]
+
+    events = uow.collect_events()
+    events.append(
+        TestEvent(aggregate_id=uuid4(), event_type="TestEvent", test_data="more data")
+    )
+
+    # Original list should not be modified
+    assert len(uow._domain_events) == 1
+
+
+def test_clear_events(uow: SQLAlchemyUnitOfWork) -> None:
+    """Test clearing events."""
+    uow._domain_events = [
+        TestEvent(aggregate_id=uuid4(), event_type="TestEvent", test_data="data")
+    ]
+
+    uow.clear_events()
+
+    assert len(uow._domain_events) == 0


### PR DESCRIPTION
## Summary

Implements foundational shared infrastructure for Domain-Driven Design that all features will use:

- ✅ **Entity-Model Mapper** - Generic `BaseMapper[TEntity, TModel]` for ORM ↔ domain conversion
- ✅ **SQLAlchemy Base Model** - Common ORM model with UUID primary key and timestamps
- ✅ **Unit of Work Pattern** - Transaction boundary management with domain event collection
- ✅ **Domain Event Dispatcher** - Event publishing infrastructure with handler registration

## Architecture

### BaseMapper (`src/backend/shared/infrastructure/persistence/base_mapper.py`)
```python
class BaseMapper(Generic[TEntity, TModel]):
    def to_domain(self, model: TModel) -> TEntity
    def to_orm(self, entity: TEntity, model: TModel | None) -> TModel
    def to_domain_list(self, models: list[TModel]) -> list[TEntity]
    def to_orm_list(self, entities: list[TEntity]) -> list[TModel]
```

### SQLAlchemyUnitOfWork (`src/backend/shared/infrastructure/persistence/unit_of_work.py`)
```python
async with uow:
    entity = Mandate.create(...)
    await uow.mandate_repository.add(entity)
    await uow.commit()  # Collects and prepares domain events
# Events dispatched after commit
```

### DomainEventDispatcher (`src/backend/shared/infrastructure/messaging/event_dispatcher.py`)
```python
dispatcher.register(MandateCreated, handler)
dispatcher.dispatch_all(uow.collect_events())
```

## Test Coverage

**22 tests passing** with comprehensive coverage:
- Mapper conversion and list operations (5 tests)
- UoW transaction lifecycle and event collection (8 tests)
- Event dispatcher registration and dispatch (9 tests)

## Breaking Changes

- ✅ Fixed Pydantic v2 deprecation warning in `AggregateRoot` (replaced `Config` with `model_config`)
- ✅ Updated pytest config to remove coverage from default args (kept in test-cov script)

## Next Steps

Features can now implement concrete:
1. ORM models extending `BaseModel`
2. Mappers extending `BaseMapper`
3. Repositories using `SQLAlchemyUnitOfWork`
4. Event handlers registered with dispatcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)